### PR TITLE
Add __wakeup method to DAO for proper unserialization

### DIFF
--- a/oc-includes/osclass/classes/database/DAO.php
+++ b/oc-includes/osclass/classes/database/DAO.php
@@ -82,6 +82,16 @@
             $this->dao         = new DBCommandClass($data) ;
             $this->tablePrefix = DB_TABLE_PREFIX ;
         }
+        
+        /**
+         * Reinitialize connection to the database once the object is unserialized
+         */
+        public function __wakeup()
+        {
+            $conn              = DBConnectionClass::newInstance() ;
+            $data              = $conn->getOsclassDb();
+            $this->dao         = new DBCommandClass($data) ;
+        }
 
         /**
          * Get the result match of the primary key passed by parameter


### PR DESCRIPTION
With some versions of PHP (or possibly in some environments) the User Alerts page doesn't work due to "Couldn't fetch mysqli" error (see issue #19). I believe this is caused by unserialization of a Search object from database - once unserialized, it may have invalid database connection identifier.

I've added __wakeup method to the DAO object to reinitialize database connection. Although this is Search class specific bug, I think the reconnection should be made in the same class as connection.

Further improvement would be to to clean-up $this->dao before serialization with __sleep method or Serializable interface.
