### PR TITLE
Added HTTP/1.1 503 header to don't loose bots trust and instruct search ...

### DIFF
--- a/oc-includes/osclass/helpers/hErrors.php
+++ b/oc-includes/osclass/helpers/hErrors.php
@@ -44,7 +44,12 @@
                 <p><?php echo $message ; ?></p>
             </body>
         </html>
-        <?php die(); ?>
+        <?php 
+		// Instruct Search Engines to come back to the site after maintenance is done
+		header('HTTP/1.1 503 Service Temporarily Unavailable');
+		header('Status: 503 Service Temporarily Unavailable');
+		header('Retry-After: 900');
+        die(); ?>
     <?php }
 
     function osc_get_absolute_url() {


### PR DESCRIPTION
...engines to come back to the site after maintenance is done

IDEA: Retry-After delay could by added in the admin dashboard close to the Maintenance toggle button
