### PR TITLE
Typo - Using pasword instead of password

### DIFF
--- a/oc-admin/gui/forgot_password.php
+++ b/oc-admin/gui/forgot_password.php
@@ -1,6 +1,6 @@
 <?php
     /**
-     * OSClass software for creating and publishing online classified advertising platforms
+     * OSClass – software for creating and publishing online classified advertising platforms
      *
      * Copyright (C) 2010 OSCLASS
      *

--- a/oc-content/themes/modern/user-forgot_password.php
+++ b/oc-content/themes/modern/user-forgot_password.php
@@ -1,6 +1,6 @@
 <?php
     /*
-     *      OSClass software for creating and publishing online classified
+     *      OSClass – software for creating and publishing online classified
      *                           advertising platforms
      *
      *                        Copyright (C) 2010 OSCLASS

--- a/oc-includes/osclass/gui/user-forgot_password.php
+++ b/oc-includes/osclass/gui/user-forgot_password.php
@@ -1,6 +1,6 @@
 <?php
     /*
-     *      OSClass software for creating and publishing online classified
+     *      OSClass – software for creating and publishing online classified
      *                           advertising platforms
      *
      *                        Copyright (C) 2010 OSCLASS


### PR DESCRIPTION
Noticed you had "pasword" a couple of times in a few files. Just putting that S back in where it belongs.
