### PR TITLE
Incorrect call fix

### DIFF
--- a/oc-includes/osclass/model/Search.php
+++ b/oc-includes/osclass/model/Search.php
@@ -1124,7 +1124,7 @@
          */
         public function listCountries($zero = ">", $order = "items DESC")
         {
-           return CountryStats::newInstance()->listCities($zero, $order);
+           return CountryStats::newInstance()->listCountries($zero, $order);
         }
 
         /**


### PR DESCRIPTION
Search::listCountries used to call CountryStats::listCities. This method didn't exist.
