### PR TITLE
Plugins sort in admin uses incorrect callback; From issue #418

### DIFF
--- a/oc-includes/osclass/classes/Plugins.php
+++ b/oc-includes/osclass/classes/Plugins.php
@@ -111,7 +111,7 @@
                 foreach($plugins as $p) {
                     $extended_list[$p] = self::getInfo($p);
                 }
-                uasort($extended_list, "self::strnatcmpCustom");
+                uasort($extended_list, "strnatcmpCustom");
                 $plugins = array();
                 // Enabled
                 foreach($extended_list as $k => $v) {


### PR DESCRIPTION
Loading up admin throws following error:

>  Fatal error: Cannot call method self::strnatcmpCustom() or method 
> does not exist in \oc-includes\osclass\classes\Plugins.php on line 114

Need to drop `self::` or just remove quotes when called 
by uasort as `uasort($extended_list, self::strnatcmpCustom());`

Was first added at a1d697dc5679485fe1cd050b356d183b0a8267f5
