### PR TITLE
Fix incorrect detection of string as php-format by xgettext.

### DIFF
--- a/oc-admin/themes/modern/tools/import.php
+++ b/oc-admin/themes/modern/tools/import.php
@@ -22,6 +22,7 @@
     osc_add_hook('admin_page_header','customPageHeader');
 
     function addHelp() {
+        /* xgettext:no-php-format */
         echo '<p>' . __("Upload registers from other Osclass installations or upload new geographic information to your site. <strong>Be careful</strong>: don’t use this option if you're not 100% sure what you're doing.") . '</p>';
     }
     osc_add_hook('help_box','addHelp');


### PR DESCRIPTION
Because of "100%" in the string, xgettext thinks this is a format string. This is wrong, so add the appropriate tag to correct the heuristics.
