### PR TITLE
Reset latest items loop when reach the end

### DIFF
--- a/oc-includes/osclass/helpers/hItems.php
+++ b/oc-includes/osclass/helpers/hItems.php
@@ -942,11 +942,12 @@
     //////////
 
     /**
-     * Gets next item of last items
+     * Gets next item of latest items query
      *
-     * @return array
+     * @return boolean It returns true if there is another item available or false if there isn't
      */
     function osc_has_latest_items($total_latest_items = null, $options = array()) {
+        // if we don't have the latest items loaded, do the query
         if ( !View::newInstance()->_exists('latestItems') ) {
             $search = Search::newInstance();
             if( !is_numeric($total_latest_items) ) {
@@ -955,26 +956,36 @@
 
             View::newInstance()->_exportVariableToView('latestItems', $search->getLatestItems($total_latest_items, $options));
         }
-        if ( View::newInstance()->_exists('resources') ) {
-            View::newInstance()->_erase('resources');
+
+        // keys we want to erase from View
+        $to_erase = array('resources', 'item_category', 'metafields');
+        foreach($to_erase as $t) {
+            if ( View::newInstance()->_exists($t) ) {
+                View::newInstance()->_erase($t);
+            }
         }
-        if ( View::newInstance()->_exists('item_category') ) {
-            View::newInstance()->_erase('item_category');
-        }
-        if ( View::newInstance()->_exists('metafields') ) {
-            View::newInstance()->_erase('metafields');
-        }
-        if(View::newInstance()->_get('itemLoop')!='latest') {
+
+        // set itemLoop to latest if it's the first time we enter here
+        if(View::newInstance()->_get('itemLoop') !== 'latest') {
             View::newInstance()->_exportVariableToView('oldItem', View::newInstance()->_get('item'));
             View::newInstance()->_exportVariableToView('itemLoop', 'latest');
         }
+
+        // get next item
         $item = View::newInstance()->_next('latestItems');
+
         if(!$item) {
             View::newInstance()->_exportVariableToView('item', View::newInstance()->_get('oldItem'));
             View::newInstance()->_exportVariableToView('itemLoop', '');
         } else {
             View::newInstance()->_exportVariableToView('item', View::newInstance()->_current('latestItems'));
         }
+
+        // reset the loop once we finish just in case we want to use it again
+        if( !$item && View::newInstance()->_count('latestItems') > 0 ) {
+            View::newInstance()->_reset('latestItems');
+        }
+
         return $item;
     }
 


### PR DESCRIPTION
Now if we want to use the latest item loop we have to reset it manually in the theme after each time we use it. With this change it reset automatically after reaching the end.

If you think it's ok, before merging the pull request I'll change it in the rest of helper loops.
