### PR TITLE
Using native javascript when adding HTML in plugin-hook

### DIFF
--- a/oc-includes/osclass/frm/Item.form.class.php
+++ b/oc-includes/osclass/frm/Item.form.class.php
@@ -1237,7 +1237,8 @@
                 data: 'page=ajax&action=runhook&hook=item_<?php echo $case;?>&catId=' + cat_id,
                 dataType: 'html',
                 success: function(data){
-                    $("#plugin-hook").html(data);
+                    var element = document.getElementById('plugin-hook');
+                    element.innerHTML = data;
                 }
             });
         }
@@ -1265,7 +1266,8 @@
                 data: 'page=ajax&action=runhook&hook=item_<?php echo $case;?>&catId=' + cat_id,
                 dataType: 'html',
                 success: function(data){
-                    $("#plugin-hook").html(data);
+                    var element = document.getElementById('plugin-hook');
+                    element.innerHTML = data;
                 }
             });
         }


### PR DESCRIPTION
jQuery.html(data) wasn't working properly with a large string in IE8 and previous versions. Following a [StackOverflow answer](http://stackoverflow.com/a/9823177/403297) I changed it to native javascript.
