### PR TITLE
Add hook for admin logout

### DIFF
--- a/oc-admin/main.php
+++ b/oc-admin/main.php
@@ -32,6 +32,7 @@
         {
             switch($this->action) {
                 case('logout'):     // unset only the required parameters in Session
+                                    osc_run_hook('logout_admin');
                                     $this->logout();
                                     $this->redirectTo( osc_admin_base_url(true) );
                 break;


### PR DESCRIPTION
Osclass have a hook when an administrator logs on to the web, I added hook when logout.

``` php
osc_run_hook('logout_admin');
```

The hook name is based on the login hook.

``` php
osc_run_hook('login_admin', $admin);
```

No parameter is passed to the hook like in the frontend hook

``` php
osc_run_hook("logout");
```
