### PR TITLE
DELIMITER block support when we import SQL files

### DIFF
--- a/oc-includes/osclass/classes/database/DBCommandClass.php
+++ b/oc-includes/osclass/classes/database/DBCommandClass.php
@@ -1016,7 +1016,7 @@
         {
             $sql     = str_replace( '/*TABLE_PREFIX*/', DB_TABLE_PREFIX, $sql);
             $sql     = preg_replace('#/\*(?:[^*]*(?:\*(?!/))*)*\*/#','',($sql));
-            $queries = explode( ';', $sql );
+            $queries = $this->splitSQL($sql, ';');
 
             if( count($queries) == 0 ) {
                 return false;
@@ -1032,6 +1032,26 @@
             }
 
             return true;
+        }
+
+        /**
+         * Split sql queries, allowing DELIMITER blocks. We clean DELIMITER statements.
+         *
+         * @param string $sql
+         * @param string $explodeChars
+         * @return array
+         */
+        private function splitSQL($sql, $explodeChars)
+        {
+            if (preg_match('|^(.*)DELIMITER (\S+)\s(.*)$|isU', $sql, $matches)) {
+                $queries = explode($explodeChars, $matches[1]);
+                $recursive = $this->splitSQL($matches[3], $matches[2]);
+
+                return array_merge($queries, $recursive);
+            }
+            else {
+                return explode($explodeChars, $sql);
+            }
         }
 
         /**


### PR DESCRIPTION
If we have a trigger in SQL file, for example:

``` sql
CREATE TABLE /*TABLE_PREFIX*/t_user (
    -- ...
) ENGINE=InnoDB DEFAULT CHARACTER SET 'UTF8' COLLATE 'UTF8_GENERAL_CI';

DELIMITER //
CREATE TRIGGER /*TABLE_PREFIX*/t_user_auto_id BEFORE INSERT ON /*TABLE_PREFIX*/t_user FOR EACH ROW BEGIN
  SET new.pk_i_id = get_max_user_id()+1;
END//
DELIMITER ;

CREATE TABLE /*TABLE_PREFIX*/t_user_description (
    -- ...
) ENGINE=InnoDB DEFAULT CHARACTER SET 'UTF8' COLLATE 'UTF8_GENERAL_CI';
```

The import fails because there is a explode:

``` php
$queries = explode( ';', $sql );
```

We replace the explode for a recursive function, that allow splitting by ';' or DELIMITER blocks.

``` php
$queries = $this->splitSQL($sql, ';');
```

The function can generate empty values in some array positions, but the importSQL function, is currently filtering empty queries.

``` php
private function splitSQL($sql, $explodeChars)
{
    if (preg_match('|^(.*)DELIMITER (\S+)\s(.*)$|isU', $sql, $matches)) {
        $queries = explode($explodeChars, $matches[1]);
        $recursive = $this->splitSQL($matches[3], $matches[2]);

        return array_merge($queries, $recursive);
    }
    else {
        return explode($explodeChars, $sql);
    }
}
```
