### PR TITLE
Holes at Email ban rules 

### DIFF
--- a/oc-includes/osclass/helpers/hSecurity.php
+++ b/oc-includes/osclass/helpers/hSecurity.php
@@ -196,8 +196,9 @@
         if($rules==null) {
             $rules = BanRule::newInstance()->listAll();
         }
+        $email = strtolower($email);
         foreach($rules as $rule) {
-            $rule = str_replace("*", ".*", str_replace(".", "\.", $rule['s_email']));
+            $rule = str_replace("*", ".*", str_replace(".", "\.", strtolower($rule['s_email'])));
             if($rule!='') {
                 if(substr($rule,0,1)=="!") {
                     $rule = '|^((?'.$rule.').*)$|';


### PR DESCRIPTION
Email ban check is case sensitive. If the rules and contact email have different character case (ITSME@GMAIL.COM and itsme@gmail.com) , then email is not banned. 
