### PR TITLE
Cookie Domain for subdomain (#1031 and #936)

### DIFF
--- a/oc-includes/osclass/core/Session.php
+++ b/oc-includes/osclass/core/Session.php
@@ -36,6 +36,9 @@
 
         function session_start() {
             $currentCookieParams = session_get_cookie_params();
+            if ( defined('COOKIE_DOMAIN') ) {
+                $currentCookieParams["domain"] = COOKIE_DOMAIN;
+            }
             session_set_cookie_params(
                 $currentCookieParams["lifetime"],
                 $currentCookieParams["path"],


### PR DESCRIPTION
COOKIE DOMAIN must be set in config if user want to use COOKIE DOMAIN.

Please consider to put DOMAIN HOST at config.php too…

THis is pull request for #1031 and #936 .
