### PR TITLE
It should be ob_end_clean

### DIFF
--- a/oc-includes/osclass/utils.php
+++ b/oc-includes/osclass/utils.php
@@ -1693,7 +1693,7 @@ function osc_csrfguard_start() {
 
 function osc_redirect_to($url) {
     if(ob_get_length()>0) {
-        ob_end_flush();
+        ob_end_clean();
     }
     header("Location: ".$url);
     exit;


### PR DESCRIPTION
Hi @conejo

I still thinking that it should be ob_end_clean.

the *_clean variants just empty the buffer, whereas *_flush functions,
also print what's in it. (send the contents to the output buffer)

Using ob_end_clean, redirection work.
Using ob_end_flush, redirection does not work.
( then why is it still there? )

I have read http://stackoverflow.com/questions/8028957/headers-already-sent-by-php

But OSclass already use buffering and that link also said that:

```
Output buffering as workaround

PHPs output buffering is suitable to alleviate this issue. It often does so quite reliaby, but should be considered strictly a workaround. Its actual purpose is minimizing chunked transfers to the webserver. Restructuring the application to avoid premature output is preferable.

Nevertheless does the output_buffering= setting help. Configure it in the php.ini* or via .htaccess* or even .user.ini*. With that enabled content gets buffered and not instantly passed on to the webserver. Thus HTTP headers can be aggregated.

It can likewise be engaged with a call to ob_start(); atop the invocation script. This however is less reliable for a few reasons:

    Even if <?php ob_start(); ?> starts the first script, whitespace or a BOM can get shuffled before, rendering it ineffective.*
    It can conceal whitespace for HTML output; but as soon as the application logic attempts to send binary content (a generated image for example), the buffered extraneous spaces become a problem. (Though ob_clean() often is another workaround.)
    The buffer is limited in size. While usually a hypothetical problem, it might however overrun - which wouldn't be easy to trace.

See also the basic usage example in the manual, and for more pros and cons:

    what is output buffering?
    Why use output buffering in PHP?
    Is using output buffering considered a bad practice?
    Use case for output buffering as the correct solution to "headers already sent"
```

I think this is good simple solution for redirection, (better than using javascript)
