### PR TITLE
Correcting data return from osc_get_latest_searches

### DIFF
--- a/oc-includes/osclass/helpers/hSearch.php
+++ b/oc-includes/osclass/helpers/hSearch.php
@@ -759,7 +759,7 @@
         if ( !View::newInstance()->_exists('latest_searches') ) {
             View::newInstance()->_exportVariableToView('latest_searches', LatestSearches::newInstance()->getSearches($limit) );
         }
-        return View::newInstance()->_count('latest_searches');
+        return View::newInstance()->_get('latest_searches');
     }
 
     /**


### PR DESCRIPTION
The osc_get_latest_searches is returning the count instead of the array
_count has been replaced with _get to return the array of latest searches
