### PR TITLE
Hide disabled category

### DIFF
--- a/oc-includes/osclass/model/Category.php
+++ b/oc-includes/osclass/model/Category.php
@@ -445,10 +445,13 @@
          * @param integer$cat_id
          * @return array
          */
-        public function findSubcategories($categoryID)
+        public function findSubcategories($categoryID, $is_enabled = true)
         {
             // juanramon: specific condition
             $this->dao->where( 'fk_i_parent_id', $categoryID );
+            if ($is_enabled == true) {
+                $this->dao->where( 'b_enabled', 1 );
+            }
             // end specific condition
 
             return $this->listWhere();


### PR DESCRIPTION
findSubcategory is called at bender refine category Search.

I'm not sure about is_enabled default value, but I think it should be =
true.

With default = true, category at oc-admin still working.
