### PR TITLE
Fixed function osc_comments_pagination when osc_item_total_comments() <=...

### DIFF
--- a/oc-includes/osclass/helpers/hPagination.php
+++ b/oc-includes/osclass/helpers/hPagination.php
@@ -48,7 +48,7 @@
      * @return string pagination links
      */
     function osc_comments_pagination() {
-        if( (osc_comments_per_page() == 0) || (osc_item_comments_page() === 'all') ) {
+        if( (osc_comments_per_page() == 0) || (osc_item_comments_page() === 'all') || (osc_item_total_comments() <= osc_comments_per_page()) ) {
             return '';
         } else {
             $params = array('total'    => ceil(osc_item_total_comments()/osc_comments_per_page())


### PR DESCRIPTION
... osc_comments_per_page()

When osc_item_total_comments() <= osc_comments_per_page(), 
only 1 page, no need to return a link to the 1 and only page
