### PR TITLE
Use Slug for region and city search parameter - Save URL

### DIFF
--- a/oc-includes/osclass/helpers/hSearch.php
+++ b/oc-includes/osclass/helpers/hSearch.php
@@ -374,7 +374,10 @@
                     if(is_numeric($params['sRegion'])) {
                         $region = Region::newInstance()->findByPrimaryKey($params['sRegion']);
                     } else {
-                        $region = Region::newInstance()->findByName($params['sRegion']);
+                        $region = Region::newInstance()->findBySlug($params['sRegion']);
+                        if (!isset($region['s_slug'])) {
+                            $region = Region::newInstance()->findByName($params['sRegion']);
+                        }
                     }
                     if(isset($region['s_slug'])) {
                         $base_url = $http_url.$region['s_slug'].".".osc_subdomain_host().REL_WEB_URL;
@@ -394,7 +397,10 @@
                     if(is_numeric($params['sCity'])) {
                         $city = City::newInstance()->findByPrimaryKey($params['sCity']);
                     } else {
-                        $city = City::newInstance()->findByName($params['sCity']);
+                        $city = City::newInstance()->findBySlug($params['sCity']);
+                        if(!isset($city['s_slug'])) {
+                            $city = City::newInstance()->findByName($params['sCity']);
+                        }
                     }
                     if(isset($city['s_slug'])) {
                         $base_url = $http_url.$city['s_slug'].".".osc_subdomain_host().REL_WEB_URL;
@@ -468,7 +474,10 @@
                     if(is_numeric($params['sRegion'])) {
                         $region = Region::newInstance()->findByPrimaryKey($params['sRegion']);
                     } else {
-                        $region = Region::newInstance()->findByName($params['sRegion']);
+                        $region = Region::newInstance()->findBySlug($params['sRegion']);
+                        if (!isset($region['s_slug'])) {
+                            $region = Region::newInstance()->findByName($params['sRegion']);
+                        } 
                     }
                     $url .= osc_sanitizeString($region['s_slug']) . '-r' . $region['pk_i_id'];
                 }
@@ -495,7 +504,10 @@
                     if(is_numeric($params['sCity'])) {
                         $city = City::newInstance()->findByPrimaryKey($params['sCity']);
                     } else {
-                        $city = City::newInstance()->findByName($params['sCity']);
+                        $city = City::newInstance()->findBySlug($params['sCity']);
+                        if(!isset($city['s_slug'])) {
+                            $city = City::newInstance()->findByName($params['sCity']);
+                        }
                     }
                     $url .= osc_sanitizeString($city['s_slug']) . '-c' . $city['pk_i_id'];
                 }


### PR DESCRIPTION
According to http://www.ietf.org/rfc/rfc1738.txt :

Unsafe:

   Characters can be unsafe for a number of reasons.  The space
character is unsafe because significant spaces may disappear and
insignificant spaces may be introduced when URLs are transcribed or
typeset or subjected to the treatment of word-processing programs. The
characters "<" and ">" are unsafe because they are used as the
delimiters around URLs in free text; the quote mark (""") is used to
delimit URLs in some systems.  The character "#" is unsafe and should
always be encoded because it is used in World Wide Web and in other
systems to delimit a URL from a fragment/anchor identifier that might
follow it.  The character "%" is unsafe because it is used for
encodings of other characters.  Other characters are unsafe because
gateways and other transport agents are known to sometimes modify such
characters. These characters are "{", "}", "|", "\", "^", "~", "[",
"]", and "`".
