### PR TITLE
passed params to pre_send_email filter, attr like to, subject, from, body...

### DIFF
--- a/oc-includes/osclass/utils.php
+++ b/oc-includes/osclass/utils.php
@@ -438,7 +438,7 @@ function osc_sendMail($params) {
     $mail->CharSet = 'utf-8';
     $mail->IsHTML(true);
 
-    $mail = osc_apply_filter('pre_send_mail', $mail);
+    $mail = osc_apply_filter('pre_send_mail',$mail, $params);
 
     // send email!
     try {


### PR DESCRIPTION
This way I can change phpmailer to other sender, only with $mail phpMailer object I cannot get **to** param to send the email via the filter.

If want to prevent sending email via phpMailer right now I can do it.

Can we add a return value from the function called by the filter to prevent the email to be sent?
