### PR TITLE
Load reCAPTCHA using SSL if necessary

### DIFF
--- a/oc-includes/osclass/helpers/hUtils.php
+++ b/oc-includes/osclass/helpers/hUtils.php
@@ -104,12 +104,12 @@ function osc_show_recaptcha($section = '') {
             case('recover_password'):
                 $time  = Session::newInstance()->_get('recover_time');
                 if((time()-$time)<=1200) {
-                    echo recaptcha_get_html( osc_recaptcha_public_key() )."<br />";
+                    echo recaptcha_get_html( osc_recaptcha_public_key(), null, osc_is_ssl() )."<br />";
                 }
                 break;
 
             default:
-                echo recaptcha_get_html( osc_recaptcha_public_key() );
+                echo recaptcha_get_html( osc_recaptcha_public_key(), null, osc_is_ssl() );
                 break;
         }
     }


### PR DESCRIPTION
If the Osclass instance is using a SSL connection, reCAPTCHA needs to be loaded using SSL as well.
