### PR TITLE
Use function splitSQL introduced on #966 when update Osclass

### DIFF
--- a/oc-includes/osclass/classes/database/DBCommandClass.php
+++ b/oc-includes/osclass/classes/database/DBCommandClass.php
@@ -1373,7 +1373,7 @@
         {
             error_log(' ----- START updateDB ----- ');
             if(!is_array($queries)) {
-                $queries = explode(";", $queries);
+                $queries = $this->splitSQL($queries, ';');
             }
 
             // Prepare and separate the queries


### PR DESCRIPTION
If we have delimiters block on sql script, works on fresh install, but fails on update osclass to new version.
