### PR TITLE
BUG - custom maintenance page #1338

### DIFF
--- a/index.php
+++ b/index.php
@@ -40,17 +40,19 @@
 
     if( file_exists(ABS_PATH . '.maintenance') ) {
         if(!osc_is_admin_user_logged_in()) {
+            
+            header('HTTP/1.1 503 Service Temporarily Unavailable');
+            header('Status: 503 Service Temporarily Unavailable');
+            header('Retry-After: 900');
+            
             if(file_exists(WebThemes::newInstance()->getCurrentThemePath().'maintenance.php')) {
                 osc_current_web_theme_path('maintenance.php');
+                die();
             } else {
                 require_once LIB_PATH . 'osclass/helpers/hErrors.php';
 
                 $title   = sprintf(__('Maintenance &raquo; %s'), osc_page_title());
                 $message = sprintf(__('We are sorry for any inconvenience. %s is undergoing maintenance.') . '.', osc_page_title() );
-
-                header('HTTP/1.1 503 Service Temporarily Unavailable');
-                header('Status: 503 Service Temporarily Unavailable');
-                header('Retry-After: 900');
                 osc_die($title, $message);
             }
         } else {


### PR DESCRIPTION
You need to add die(); code to the custom maintenance page in the first index.php.
Because if they have one, process is still running . So we have displayed the custom.php and home.php.

I moved too header code to apply it on each case.
