### PR TITLE
BUG - add osc_esc_js function in ajax_photos #1336

### DIFF
--- a/oc-includes/osclass/frm/Item.form.class.php
+++ b/oc-includes/osclass/frm/Item.form.class.php
@@ -1505,7 +1505,7 @@
                             json.success = true;
                         } else {
                             json.success = false;
-                            $('#restricted-fine-uploader .qq-uploader').after($('<div class="alert alert-error"><?php echo sprintf(__('Too many items were uploaded. Item limit is %d.'), $maxImages); ?></div>'));
+                            $('#restricted-fine-uploader .qq-uploader').after($('<div class="alert alert-error"><?php echo osc_esc_js(sprintf(__('Too many items were uploaded. Item limit is %d.'), $maxImages)); ?></div>'));
                         }
                         return json;
                     }


### PR DESCRIPTION
Hi,

You need to add addslashes function tu ajax_photos() in Item.form.class.php

$('#restricted-fine-uploader .qq-uploader').after($('

<?php echo addslashes(sprintf(__('Too many items were uploaded. Item limit is %d.'), $maxImages)); ?>
'));
While I'm in french, the error text have a simple quote. So the javascript fail.

Too many itmes = Trop d'images

Thanks !
