### PR TITLE
BUG - Search pagination, item per page and count

### DIFF
--- a/oc-includes/osclass/model/Search.php
+++ b/oc-includes/osclass/model/Search.php
@@ -979,9 +979,7 @@
                 // order & limit
                 $this->dao->orderBy( $this->order_column, $this->order_direction);
 
-                if($count) {
-                    $this->dao->limit(100*$this->results_per_page);
-                } else {
+                if(!$count) {
                     $this->dao->limit( $this->limit_init, $this->results_per_page);
                 }
             }


### PR DESCRIPTION
This line don't have to exist. 
On our website we have categories with more than 1K ads and 10 ads per page. But with this line we can't have more than 1K ads displayed. Users can't go to the 101 page, because pagination is set with this count.

It doesn't need to have limit to the count case.

$this->dao->limit(100*$this->results_per_page);
