### PR TITLE
[BUG] fix Division by Zero error

### DIFF
--- a/oc-admin/pages.php
+++ b/oc-admin/pages.php
@@ -231,11 +231,9 @@
                         Cookie::newInstance()->set();
                     } else {
                         // set a default value if it's set in the cookie
-                        if( Cookie::newInstance()->get_value('listing_iDisplayLength') != '' ) {
-                            Params::setParam('iDisplayLength', Cookie::newInstance()->get_value('listing_iDisplayLength'));
-                        } else {
-                            Params::setParam('iDisplayLength', 10 );
-                        }
+                        $listing_iDisplayLength = (int) Cookie::newInstance()->get_value('listing_iDisplayLength');
+                        if ($listing_iDisplayLength == 0) $listing_iDisplayLength = 10;
+                        Params::setParam('iDisplayLength', $listing_iDisplayLength );
                     }
                     $this->_exportVariableToView('iDisplayLength', Params::getParam('iDisplayLength'));
 


### PR DESCRIPTION
After upgrading, fix a cookie issue returning non-empty string but that evaluates to `0`
hence the division by zero, `Showing 0 to 0 of 0 results`, empty table, etc..
