### PR TITLE
Fix max_char_per_title & max_char_per_description

### DIFF
--- a/oc-includes/osclass/helpers/hPreference.php
+++ b/oc-includes/osclass/helpers/hPreference.php
@@ -294,7 +294,8 @@
      * @return int
      */
     function osc_max_characters_per_title() {
-        return (getPreference('title_character_length'));
+        $value = getPreference('title_character_length');
+        return ( !empty($value) ? $value : 128);
     }
 
     /**
@@ -303,7 +304,8 @@
      * @return int
      */
     function osc_max_characters_per_description() {
-        return (getPreference('description_character_length'));
+        $value = getPreference('description_character_length');
+        return ( !empty($value) ? $value : 4096);
     }
 
     /**


### PR DESCRIPTION
Avoid empty values with core 3.2- and new 3.3+ themes relying on these values

(as some people upgraded themes but skipped 3.3+ core for some reasons)
