### PR TITLE
Fix mb_strlen replacement returning wrong value

### DIFF
--- a/oc-includes/osclass/compatibility.php
+++ b/oc-includes/osclass/compatibility.php
@@ -74,7 +74,7 @@ if ( !function_exists('mb_substr') ) {
 
 if ( !function_exists('mb_strlen') ) {
     function mb_strlen($str, $encoding = null ) {
-        return strlen($str);
+        return strlen(utf8_decode($str));
     }
 }
 


### PR DESCRIPTION
see http://wpengineer.com/2410/dont-use-strlen/
