### PR TITLE
Fix substring cut in items titles

### DIFF
--- a/oc-includes/osclass/classes/datatables/ItemsDataTable.php
+++ b/oc-includes/osclass/classes/datatables/ItemsDataTable.php
@@ -224,7 +224,7 @@
                     $options = array();
                     // -- prepare data --
                     // prepare item title
-                    $title = mb_substr($aRow['s_title'], 0, 30, 'utf-8');
+                    $title = mb_strcut($aRow['s_title'], 0, 30, 'utf-8');
                     if($title != $aRow['s_title']) {
                         $title .= '...';
                     }
@@ -320,7 +320,7 @@
                     $options = array();
                     // -- prepare data --
                     // prepare item title
-                    $title = mb_substr($aRow['s_title'], 0, 30, 'utf-8');
+                    $title = mb_strcut($aRow['s_title'], 0, 30, 'utf-8');
                     if($title != $aRow['s_title']) {
                         $title .= '...';
                     }


### PR DESCRIPTION
Fix multi-byte characters cut

> mb_strcut() extracts a substring from a string similarly to mb_substr(), but operates on bytes instead of characters. If the cut position happens to be between two bytes of a multi-byte character, the cut is performed starting from the first byte of that character. This is also the difference to the substr() function, which would simply cut the string between the bytes and thus result in a malformed byte sequence.
