### PR TITLE
Fix invalid href in osc_die stylesheet

### DIFF
--- a/oc-includes/osclass/helpers/hErrors.php
+++ b/oc-includes/osclass/helpers/hErrors.php
@@ -38,7 +38,7 @@
             <head>
                 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
                 <title><?php echo $title; ?></title>
-                <link rel="stylesheet" type="text/css" media="all" href="<?php echo osc_get_absolute_url(); ?>oc-includes/osclass/installer/install.css" />
+                <link rel="stylesheet" type="text/css" media="all" href="/oc-includes/osclass/installer/install.css" />
             </head>
             <body class="page-error">
                 <p><?php echo $message; ?></p>


### PR DESCRIPTION
e.g. when called from a pretty URL/permalink, `osc_get_absolute_url` returns an invalid URL

actually the fix should be made on `function osc_get_absolute_url`
