### PR TITLE
Update osc_get_flash_message with dropMessage option

### DIFF
--- a/oc-includes/osclass/helpers/hMessages.php
+++ b/oc-includes/osclass/helpers/hMessages.php
@@ -123,9 +123,9 @@
      * @param string $section
      * @return string Message
      */
-    function osc_get_flash_message($section = 'pubMessages') {
+    function osc_get_flash_message($section = 'pubMessages', $dropMessages = true) {
         $message = Session::newInstance()->_getMessage($section);
-        Session::newInstance()->_dropMessage($section);
+        if ($dropMessages) Session::newInstance()->_dropMessage($section);
 
         return $message;
     }


### PR DESCRIPTION
To allow checking for pending messages without dropping them
Useful e.g. to adjust front-end when Flash messages are displayed
