### PR TITLE
Fix for 'Lower/Higher price first' search criterias

### DIFF
--- a/oc-includes/osclass/helpers/hSearch.php
+++ b/oc-includes/osclass/helpers/hSearch.php
@@ -47,11 +47,18 @@
      * @return array
      */
     function osc_list_orders() {
-        return  array(
+        if (osc_price_enabled_at_items()) {
+        return array(
                      __('Newly listed')        => array('sOrder' => 'dt_pub_date', 'iOrderType' => 'desc')
                     ,__('Lower price first')   => array('sOrder' => 'i_price', 'iOrderType' => 'asc')
                     ,__('Higher price first')  => array('sOrder' => 'i_price', 'iOrderType' => 'desc')
                 );
+        }
+        else {
+        return array(
+                     __('Newly listed')        => array('sOrder' => 'dt_pub_date', 'iOrderType' => 'desc')
+                );
+        }
     }
 
     /**


### PR DESCRIPTION
Removed irrelevant 'Lower price first' & 'Higher price first' sort criterias when items have no price (i.e. `! osc_price_enabled_at_items()`)
