### PR TITLE
Fix osc_esc_js to allow double-quotes and <br>

### DIFF
--- a/oc-includes/osclass/helpers/hSanitize.php
+++ b/oc-includes/osclass/helpers/hSanitize.php
@@ -177,7 +177,7 @@
      * @return string
      */
     function osc_esc_js($str) {
-        $new_lines = array('<br>','<br/>','<br />');
+        static $new_lines = array('<br>','<br/>','<br />');
         $str = trim(strip_tags($str, implode('',$new_lines)));
         $str = str_replace("\r", '', $str);
         $str = addslashes($str);


### PR DESCRIPTION
Translators sometimes use double-quotes `" "`, `\n` and `<br>` in their translated texts. 
Furthermore, they can't guess where nor how in the code will the string be used. in JS or HTML messages? 
Hence this fix allows complete interchangeably in JS or HTML of translated strings
