### PR TITLE
Add 2 optional params to is_company_select

### DIFF
--- a/oc-includes/osclass/frm/User.form.class.php
+++ b/oc-includes/osclass/frm/User.form.class.php
@@ -146,10 +146,10 @@
             parent::generic_input_text('zip', (isset($user['s_zip'])) ? $user['s_zip'] : null);
         }
 
-        static public function is_company_select($user = null) {
+        static public function is_company_select($user = null, $user_label = null, $company_label = null) {
             $options = array(
-                array( 'i_value' => '0', 's_text' => __('User') )
-                ,array( 'i_value' => '1', 's_text' => __('Company') )
+                array( 'i_value' => '0', 's_text' => ($user_label?:__('User')) )
+                ,array( 'i_value' => '1', 's_text' => ($company_label?:__('Company')) )
             );
 
             parent::generic_select( 'b_company', $options, 'i_value', 's_text', null, (isset($user['b_company'])) ? $user['b_company'] : null );


### PR DESCRIPTION
Improve the `is_company_select()` options texts as the text `User` is too broadly used to be relevant everywhere and especially here in the user's dashboard. (and anyway hard-coded texts should not be present imho in a back-office, or maybe/at least only as a fallback)
