### PR TITLE
BUG - Two users with same search = 2 mails each

### DIFF
--- a/oc-includes/osclass/alerts.php
+++ b/oc-includes/osclass/alerts.php
@@ -50,7 +50,7 @@
         }
 
         $active   = TRUE;
-        $searches = Alerts::newInstance()->findByType($type, $active);
+        $searches = Alerts::newInstance()->findByTypeGroup($type, $active);
 
 
         foreach($searches as $s_search) {


### PR DESCRIPTION
Hi,

So, I changed findByType by this function findByTypeGroup.

Using findByType function result to contact X users, X times if they have the same search.

For exemple, if 3 users have the same search, the first foreach will do 3 times the search and send 3 times a mail for each users.

But with findByTypeGroup, the search will be run one time and the result will be send to 3 users.
