### PR TITLE
revert changes in #1518

### DIFF
--- a/oc-admin/themes/modern/js/market.js
+++ b/oc-admin/themes/modern/js/market.js
@@ -130,7 +130,7 @@ $(function(){
                             screenshots = '<tr>'
                                 +'<td colspan="3"><h4>'+theme.langs.screenshots+'</h4>';
                                 for(i = 0; i < item.a_images.length; i++){
-                                    screenshots += '<a class="fancybox'+item.fk_i_market_id+'" href="'+item.a_images[i]['s_image']+'" class="screnshot"><img src="'+item.a_images[i]['s_thumbnail']+'" /></a>';
+                                    screenshots += '<a rel="image_group'+item.fk_i_market_id+'" href="'+item.a_images[i]['s_image']+'" class="screnshot"><img src="'+item.a_images[i]['s_thumbnail']+'" /></a>';
                                     if(i == 2) break;
                                 }
                              screenshots += '</td></tr>';


### PR DESCRIPTION
#1518 breaks fancybox in Admin (Market), and since the code is different this does not work like in frontend for Bender fix. Also, since it is in backend, strict W3C validation is not so important anyway.
