### PR TITLE
duplicate content

### DIFF
--- a/oc-includes/osclass/functions.php
+++ b/oc-includes/osclass/functions.php
@@ -199,13 +199,13 @@ function meta_description( ) {
     // search
     if( osc_is_search_page() ) {
         if( osc_has_items() ) {
-            $text = osc_item_category() . ' ' . osc_item_city() . ', ' . osc_highlight(osc_item_description(), 120) . ', ' . osc_item_category() . ' ' . osc_item_city();
+            $text = osc_item_category() . ' ' . osc_item_city() . ', ' . osc_highlight(osc_item_description(), 120);
         }
         osc_reset_items();
     }
     // listing
     if( osc_is_ad_page() ) {
-        $text = osc_item_category() . ' ' . osc_item_city() . ', ' . osc_highlight(osc_item_description(), 120) . ', ' . osc_item_category() . ' ' . osc_item_city();
+        $text = osc_item_category() . ' ' . osc_item_city() . ', ' . osc_highlight(osc_item_description(), 120);
     }
 
     return (osc_apply_filter('meta_description_filter', $text));


### PR DESCRIPTION
As already stated here #1583 (updated with new comments), this is not a fix (by no means), just a fix for the still erroneous lines IMHO. Ideally, we should have this:

if multiple categories are selected on search:
meta description = search pattern - website title

or if single category is being searched or on a category or subcategory root:
meta description = search pattern - search (sub)category - website title
