### PR TITLE
Wrong redirect if url don't match

### DIFF
--- a/oc-includes/osclass/controller/search.php
+++ b/oc-includes/osclass/controller/search.php
@@ -174,12 +174,13 @@
             }
 
 
-            $uriParams = Params::getParamsAsArray();
-            $searchUri = osc_search_url($uriParams);
+            $uriParams = Params::getParamsAsArray("get");
+            unset ($uiParams["page"]);
+             $searchUri = osc_search_url($uriParams);
             if($searchUri!=(WEB_PATH . urldecode($this->uri))) {
                 $this->redirectTo($searchUri, 301);
             }
-
+            
             ////////////////////////////////
             //GETTING AND FIXING SENT DATA//
             ////////////////////////////////


### PR DESCRIPTION
With the previous code you get too much params and all of these parameters are included to the URL

[osclass] => dc90d557238550502335...
[__utma] => 263180956.1364595168.1401294533.1404999419.14...
[__utmb] => 263180956.8.10.140507...
[__utmc] => 263180..
[__utmz] => 263180956.1401294533.1.1.utm...
[page] => search
[sCity] => ..
[sCategory] => ..
..

Maybe they have There is a better way to do it :).
