### PR TITLE
Wrong redirect if url don't match

### DIFF
--- a/oc-includes/osclass/controller/search.php
+++ b/oc-includes/osclass/controller/search.php
@@ -176,7 +176,7 @@
             if(!Params::existParam('sFeed')) {
                 $uriParams = Params::getParamsAsArray("get");
                 $searchUri = osc_search_url($uriParams);
-                if($searchUri!=(WEB_PATH . osc_get_preference('seo_url_search_prefix') . "/" . urldecode($this->uri))) {
+                if(str_replace( osc_get_preference('seo_url_search_prefix') . '/', '', osc_search_url($uriParams))!=(WEB_PATH . str_replace( osc_get_preference('seo_url_search_prefix') . '/', '', urldecode($this->uri)))) {
                     $this->redirectTo($searchUri, 301);
                 }
             }


### PR DESCRIPTION
With the previous code you get too much params and all of these parameters are included to the URL

[osclass] => dc90d557238550502335...
[__utma] => 263180956.1364595168.1401294533.1404999419.14...
[__utmb] => 263180956.8.10.140507...
[__utmc] => 263180..
[__utmz] => 263180956.1401294533.1.1.utm...
[page] => search
[sCity] => ..
[sCategory] => ..
..

Maybe they have There is a better way to do it :).

This solution is working. 
Added search prefix previously remouved in constructor
Keep page param.
