### PR TITLE
[404] geocode API call fix. Update to API v3

### DIFF
--- a/oc-content/plugins/google_maps/index.php
+++ b/oc-content/plugins/google_maps/index.php
@@ -29,7 +29,7 @@ Plugin update URI: http://www.osclass.org/files/plugins/google_maps/update.php
         $sRegion = (isset($aItem['s_region']) ? $aItem['s_region'] : '');
         $sCountry = (isset($aItem['s_country']) ? $aItem['s_country'] : '');
         $address = sprintf('%s, %s, %s, %s', $sAddress, $sCity, $sRegion, $sCountry);
-        $response = osc_file_get_contents(sprintf('http://maps.google.com/maps/geo?q=%s&output=json&sensor=false', urlencode($address)));
+        $response = osc_file_get_contents(sprintf('http://maps.googleapis.com/maps/api/geocode/json?address=%s&sensor=false', urlencode($address)));
         $jsonResponse = json_decode($response);
         if (isset($jsonResponse->Placemark) && count($jsonResponse->Placemark[0]) > 0) {
             $coord = $jsonResponse->Placemark[0]->Point->coordinates;


### PR DESCRIPTION
"Status": {
  "code": 610,
  "request": "geocode",
  "error_message": "The Geocoding API v2 has been turned down on September 9th, 2013. The Geocoding API v3 should be used now. Learn more at https://developers.google.com/maps/documentation/geocoding/"
}
