### PR TITLE
Reorganize Admin Menu

### DIFF
--- a/oc-includes/osclass/classes/AdminMenu.php
+++ b/oc-includes/osclass/classes/AdminMenu.php
@@ -54,8 +54,6 @@
             $this->add_submenu( 'items', __('Reported listings'), osc_admin_base_url(true).'?page=items&action=items_reported', 'items_reported', 'moderator');
             $this->add_submenu( 'items', __('Manage media'), osc_admin_base_url(true).'?page=media', 'items_media', 'moderator');
             $this->add_submenu( 'items', __('Comments'), osc_admin_base_url(true).'?page=comments', 'items_comments', 'moderator');
-            $this->add_submenu( 'items', __('Custom fields'), osc_admin_base_url(true).'?page=cfields', 'items_cfields', 'administrator');
-            $this->add_submenu( 'items', __('Settings'), osc_admin_base_url(true).'?page=items&action=settings', 'items_settings', 'administrator');
 
             $this->add_menu( __('Market'), osc_admin_base_url(true) .'?page=market', 'market', 'administrator');
             $this->add_submenu( 'market', __('Themes'), osc_admin_base_url(true) .'?page=market&action=themes', 'market_view_themes', 'administrator');
@@ -79,6 +77,8 @@
 
             $this->add_menu(__('Settings'), osc_admin_base_url(true) .'?page=settings', 'settings', 'administrator');
             $this->add_submenu( 'settings', __('General'), osc_admin_base_url(true) .'?page=settings', 'settings_general', 'administrator');
+            $this->add_submenu( 'settings', __('Custom fields'), osc_admin_base_url(true).'?page=cfields', 'items_cfields', 'administrator');
+            $this->add_submenu( 'settings', __('Listing Settings'), osc_admin_base_url(true).'?page=items&action=settings', 'items_settings', 'administrator');
             $this->add_submenu( 'settings',__('Categories'), osc_admin_base_url(true) .'?page=categories', 'settings_categories', 'administrator');
             $this->add_submenu( 'settings', __('Comments'), osc_admin_base_url(true) .'?page=settings&action=comments', 'settings_comments', 'administrator');
             $this->add_submenu( 'settings', __('Locations'), osc_admin_base_url(true) .'?page=settings&action=locations', 'settings_locations', 'administrator');


### PR DESCRIPTION
small suggestion for admin menu change, move Listings Settings and Custom Fields settings under Settings menu, this way will leverage simplicity of Manage Listings/Comments menu for everyday use.

CFs and general Listing Settings are not usually accessed on a daily basis and changed frequently.