### PR TITLE
add new filter to modify assets path

### DIFF
--- a/oc-includes/osclass/WebThemes.php
+++ b/oc-includes/osclass/WebThemes.php
@@ -100,9 +100,9 @@
         public function setCurrentThemeUrl()
         {
             if ( $this->theme_exists ) {
-                $this->theme_url = osc_base_url() . str_replace(osc_base_path(), '', $this->theme_path);
+                $this->theme_url = osc_apply_filter('theme_url', osc_base_url() . str_replace(osc_base_path(), '', $this->theme_path));
             } else {
-                $this->theme_url = osc_base_url() . 'oc-includes/osclass/gui/';
+                $this->theme_url = osc_apply_filter('theme_url', osc_base_url() . 'oc-includes/osclass/gui/');
             }
         }
 

--- a/oc-includes/osclass/classes/Scripts.php
+++ b/oc-includes/osclass/classes/Scripts.php
@@ -85,7 +85,7 @@ class Scripts extends Dependencies {
     public function printScripts()
     {
         foreach($this->getScripts() as $script) {
-            echo '<script type="text/javascript" src="' . $script . '"></script>' . PHP_EOL;
+            echo '<script type="text/javascript" src="' . osc_apply_filter('script_url', $script) . '"></script>' . PHP_EOL;
         }
     }
 }

--- a/oc-includes/osclass/classes/Styles.php
+++ b/oc-includes/osclass/classes/Styles.php
@@ -59,7 +59,7 @@ class Styles {
     public function printStyles()
     {
         foreach($this->styles as $css) {
-            echo '<link href="'.$css.'" rel="stylesheet" type="text/css" />' . PHP_EOL;
+            echo '<link href="' . osc_apply_filter('style_url', $css) . '" rel="stylesheet" type="text/css" />' . PHP_EOL;
         }
     }
 }


### PR DESCRIPTION
Hi!

Thanks for amazing script

I write a small improvement - in my osclass site i mixed http/https protocols (https only on login, register, and other pages).
But all assets js, css files have hardcoded http protocol in url.
Writing in core is badly but allow to modify by filters is ok :smile: 

```
str_replace(array('http://', 'https://'), '//', $url)
```

Example output:

```
<link href="//oc-content/themes/xxx/css/main.css" rel="stylesheet" type="text/css" />
```
