### PR TITLE
Add filter in search to add data from plugins to items

### DIFF
--- a/oc-includes/osclass/controller/search.php
+++ b/oc-includes/osclass/controller/search.php
@@ -479,6 +479,8 @@
                 $_cache['iTotalItems'] = $iTotalItems;
                 osc_cache_set($key, $_cache, OSC_CACHE_TTL);
             }
+            
+            $aItems = osc_apply_filter('pre_show_items', $aItems);
 
             $iStart    = $p_iPage * $p_iPageSize;
             $iEnd      = min(($p_iPage+1) * $p_iPageSize, $iTotalItems);


### PR DESCRIPTION
Hi,

Just an idea but so useful for plugins. <3

If found this line on item controller :

``` PHP
$item = osc_apply_filter('pre_show_item', $this->itemManager->findByPrimaryKey( Params::getParam('id') ));
```

And it's perfect to complete an item with data from plugins with array_merge.  After this I create an helper in my plugin who use osc_item_field('plugin_filed', locale).

This new line will allow users to use plugins helpers to display new informations on search.

If you like this we can add this line wherever an array of item is exported. And add the line pre_show_item wherever an item is exported.

Regards
