### PR TITLE
set image bit depth

### DIFF
--- a/oc-includes/osclass/classes/ImageResizer.php
+++ b/oc-includes/osclass/classes/ImageResizer.php
@@ -142,6 +142,7 @@
                     $this->im = $bg;
                     $this->ext = 'jpeg';
                 }
+                $this->im->setImageDepth(8);
                 $this->im->setImageFileName($imagePath);
                 $this->im->setImageFormat($ext);
                 $this->im->writeImage($imagePath);


### PR DESCRIPTION
Alt solution for large PNG files with imagick (excessive 16 bit/ch bit depth).
Optionally it can be wrapped with if construct for png, but since jpegs are already at 8 bit, not really needed.