### PR TITLE
BUG find Users By Search And Type

### DIFF
--- a/oc-includes/osclass/model/Alerts.php
+++ b/oc-includes/osclass/model/Alerts.php
@@ -218,7 +218,7 @@
             if($active){
                 $this->dao->where('b_active', 1);
             }
-            $this->dao->groupBy('s_search');
+            
             $result = $this->dao->get();
 
             if($result == false) {


### PR DESCRIPTION
I find a bug

I removed this line : $this->dao->groupBy('s_search'); because this function is to find each users with the same search. With a group by, I will always have one user. It's not meant to be like that.

Thanks!