### PR TITLE
BUG - Just a fix to make the unsubscribe link work

### DIFF
--- a/oc-includes/osclass/alerts.php
+++ b/oc-includes/osclass/alerts.php
@@ -74,7 +74,8 @@
                     }
 
                     foreach($users as $user) {
-                        osc_run_hook('hook_'.$internal_name, $user, $ads, $s_search, $items, $totalItems);
+                        //@todo rename $users in $alerts and remove $s_search in this hook
+                        osc_run_hook('hook_'.$internal_name, $user, $ads, $user, $items, $totalItems);
                         AlertsStats::newInstance()->increase(date('Y-m-d'));
                     }
                 }


### PR DESCRIPTION
Hi, 
I just found a bug in the unsubscribe link.
$s_search and $user are both a results from the alerts table.

The unsubscribe link is created with the s_search param but the s_search var is the alert grouped by the related search.
If you create the unsubscribe link with $s_search and if theres is multiple user that have subscribed to the same search, the unsubscribe link is wrong because it's created with the wrong ID and secret.

The good param is $user which is one alert from a specific search corresponding to one user to send the right id and secret to the alert.

@TODO remove s_search from the hook in emails.php for each alert and in alerts.php 
@TODO rename $users in $alerts in emails.php for each alert  and in alerts.php
@TODO rename $user in $alert in emails.php for each alert and in alerts.php
