### PR TITLE
remove comments for hook removals

### DIFF
--- a/oc-includes/osclass/ItemActions.php
+++ b/oc-includes/osclass/ItemActions.php
@@ -164,7 +164,6 @@
             }
 
             // hook pre add or edit
-            // DEPRECATED: pre_item_post will be removed in 3.4
             osc_run_hook('pre_item_post');
             osc_run_hook('pre_item_add', $aItem);
 

--- a/oc-includes/osclass/helpers/hAdminMenu.php
+++ b/oc-includes/osclass/helpers/hAdminMenu.php
@@ -36,7 +36,7 @@
         $aMenu              = $adminMenu->get_array_menu();
         $current_menu_id    = osc_current_menu();
         $is_moderator       = osc_is_moderator();
-        // DEPRECATED : Remove hook admin_menu when osclass 4.0 be released
+
         // hack, compatibility with menu plugins.
         ob_start();
         osc_run_hook('admin_menu');


### PR DESCRIPTION
474ba41
I don't know why was this marked for removal (probably because some equivalent hook was introduced instead), but this would bring havoc to many plugins and custom functions out there. Since we passed v3.4x and this did not happen /thankfully/ it's time to be discarded.

9df9b4a
Again, I hardly see any reason for removal of this hook -- it will simply break so many plugins out there without any particular reason at all [!]

Personally, I never liked the new admin menu, it does not work in sync along with the old hook. Plugins with new menu are always listed first, not following later installation order as they should, not to mention plugins which use their own flashy icons, which combined with fixed positioning (esp. in compact toolbar mode) and small screen devices results in serious (in)accessibility issue.