### PR TITLE
Add additional ban rule example

### DIFF
--- a/oc-admin/themes/modern/users/ban_frm.php
+++ b/oc-admin/themes/modern/users/ban_frm.php
@@ -83,7 +83,7 @@
                     <div class="form-label"><?php _e('E-mail rule'); ?></div>
                     <div class="form-controls">
                         <?php BanRuleForm::email_text($rule); ?>
-                        <span class="help-box"><?php _e('(e.g. *@badsite.com)'); ?></span>
+                        <span class="help-box"><?php _e('(e.g. *@badsite.com, *@subdomain.badsite.com, *@*badsite.com)'); ?></span>
                     </div>
                 </div>
                 <div class="clear"></div>

--- a/oc-content/languages/en_US/core.po
+++ b/oc-content/languages/en_US/core.po
@@ -4314,7 +4314,7 @@ msgid "E-mail rule"
 msgstr ""
 
 #: oc-admin/themes/modern/users/ban_frm.php:87
-msgid "(e.g. *@badsite.com)"
+msgid "(e.g. *@badsite.com, *@subdomain.badsite.com, *@*badsite.com)"
 msgstr ""
 
 #: oc-admin/themes/modern/users/frm.php:35


### PR DESCRIPTION
If we want to block [1] just a root email domain, [2] single email subdomain or [3] entire email domain including all subdomains these are the proper wildcard examples.