### PR TITLE
Allow theme specialized versions of files to be loaded if they exist.

### DIFF
--- a/oc-includes/osclass/helpers/hTheme.php
+++ b/oc-includes/osclass/helpers/hTheme.php
@@ -39,8 +39,8 @@
         // Clean $file to prevent hacking of some type
         osc_sanitize_url($file);
         $file = str_replace("../", "", str_replace("..\\", "", str_replace("://", "", preg_replace("|http([s]*)|", "", $file))));
-        if(file_exists(osc_theme() . $file)) {
-            include osc_themes_path() . $file;
+        if(file_exists(osc_themes_path() . osc_theme() . '/' . $file)) {
+            include osc_themes_path() . osc_theme() . '/' . $file;
         } else if(file_exists(osc_plugins_path() . $file)) {
             include osc_plugins_path() . $file;
         }


### PR DESCRIPTION
I could be misinterpreting the intentions, but from my understanding of the code this is probably meant to allow theme specific implementations of the file to render. This would be possible by having the function check for the file under the current web theme folder first and then try to grab it from the plugin folder. If this is the case it will never work. 

Example

If we have use the theme named bender and we have a file for our route 'pluginname/user/foo.php', the file will be looked for at

benderpluginname/user/foo.php

So

if(file_exists(osc_theme() . $file)) {
            include osc_themes_path() . $file;

should probably be

if(file_exists(osc_themes_path() . osc_theme() . '/' . $file)) {
            include osc_themes_path() . osc_theme() . '/' . $file;

A workaround to use relative paths to allow people to place specialized versions of files in the theme does not work either since checks in this function and various other places filters things like ../.

So currently you are only able to include files placed under your plugin with this function.

If the intent is not to allow placement of specialized files under the theme but instead check for a specialized version for a theme under the plugin itself, like plugin/user/foo.php first checking if plugin/user/bender/foo.php exists, this doesn't work with the current code either.

The proposed change would allow the following

oc-plugins/myplugin/user/foo.php

could have a special implementation in

oc-themes/bender/myplugin/user/foo.php

If it existed the file under the theme would be used instead of the default on in the plugin.

One idea could probably be to add a default folder under the theme for files like this. For instance 'plugins' or something similar to keep them in a known place and not confuse them with the rest of the theme files. In that case something like

if(file_exists(osc_themes_path() . osc_theme() . '/plugins/' . $file)) {
            include osc_themes_path() . osc_theme() . '/plugins/' . $file;

would probably work.

Personally I hold no preference to allow the files to be places under the theme. I could very well live with them in theme specific folders under each plugin. But from my initial glimpse at the code here it feels like the original intent is not what the code accomplishes.
