### PR TITLE
Fixed the "osc_render_file" not rendering theme files

### DIFF
--- a/oc-includes/osclass/helpers/hTheme.php
+++ b/oc-includes/osclass/helpers/hTheme.php
@@ -39,7 +39,7 @@
         // Clean $file to prevent hacking of some type
         osc_sanitize_url($file);
         $file = str_replace("../", "", str_replace("..\\", "", str_replace("://", "", preg_replace("|http([s]*)|", "", $file))));
-        if(file_exists(osc_theme() . $file)) {
+        if(file_exists(osc_themes_path() . $file)) {
             include osc_themes_path() . $file;
         } else if(file_exists(osc_plugins_path() . $file)) {
             include osc_plugins_path() . $file;


### PR DESCRIPTION
The "osc_render_file" function had the wrong themes path while checking if the theme file existed, causing never to render theme files, all I did was substitute de "osc_theme()" function call at line 42 by the right "osc_themes_path()" call, allowing theme files to be rendered.
