### PR TITLE
Remove clear session variable for ajax calls

### DIFF
--- a/oc-includes/osclass/controller/ajax.php
+++ b/oc-includes/osclass/controller/ajax.php
@@ -321,9 +321,6 @@
                     echo json_encode(array('error' => __('no action defined')));
                 break;
             }
-            // clear all keep variables into session
-            Session::newInstance()->_dropKeepForm();
-            Session::newInstance()->_clearVariables();
         }
 
         //hopefully generic...


### PR DESCRIPTION
Hi,

Maybe there is another way but clearing session variable for ajax calls broke some functionalities.

For exemple, with Madhouse messenger, we are using an ajax call to display number of unread messages. When we are on item post page this ajax call remove variable in session so if the form have some error, we can't use keepform variables because they have been dropped by this ajax call.

Same case in the search page. If we use ajax call in this page alerts doesn't work anymore because 'alert_signature' is dropped by the ajax call. 

Regards
