### PR TITLE
Use $user instead of $s_search for unsub link

### DIFF
--- a/oc-includes/osclass/alerts.php
+++ b/oc-includes/osclass/alerts.php
@@ -74,7 +74,7 @@
                     }
 
                     foreach($users as $user) {
-                        osc_run_hook('hook_'.$internal_name, $user, $ads, $s_search, $items, $totalItems);
+                        osc_run_hook('hook_'.$internal_name, $user, $ads, $user, $items, $totalItems);
                         AlertsStats::newInstance()->increase(date('Y-m-d'));
                     }
                 }


### PR DESCRIPTION
If you send $s_search the unsub link will not work because the s_secret will be wrong if more than one user have the same alert. Users will not be able to unsub with the link in the email.
