### PR TITLE
fix spelling of "formatted"

### DIFF
--- a/oc-includes/osclass/helpers/hItems.php
+++ b/oc-includes/osclass/helpers/hItems.php
@@ -270,12 +270,23 @@
     }
 
     /**
-     * Gets formated price of current item
+     * Gets formatted price of current item
+     *
+     * @return string
+     */
+    function osc_item_formatted_price() {
+        return (string) osc_format_price( osc_item_price() );
+    }
+
+    /**
+     * DEPRECATED: incorrect spelling of "formatted." Kept for legacy purposes
+     *
+     * Calls osc_item_formatted_price
      *
      * @return string
      */
     function osc_item_formated_price() {
-        return (string) osc_format_price( osc_item_price() );
+      return osc_item_formatted_price();
     }
 
     /**


### PR DESCRIPTION
The word "formatted" is spelled incorrectly in `hItems.php`. This PR fixes it, but leaves the old function signature available.

Documentation should also be updated [here](https://doc.osclass.org/HItems.php)
