### PR TITLE
Pattern search work with all languages simultaneously

### DIFF
--- a/oc-includes/osclass/model/Search.php
+++ b/oc-includes/osclass/model/Search.php
@@ -916,14 +916,6 @@
                 if ($this->withPattern ) {
                     $this->dao->join(DB_TABLE_PREFIX.'t_item_description as d','d.fk_i_item_id = '.DB_TABLE_PREFIX.'t_item.pk_i_id','LEFT');
                     $this->dao->where(sprintf("MATCH(d.s_title, d.s_description) AGAINST('%s' IN BOOLEAN MODE)", $this->sPattern) );
-                    if(empty($this->locale_code)) {
-                        if(OC_ADMIN) {
-                            $this->locale_code[osc_current_admin_locale()] = osc_current_admin_locale();
-                        } else {
-                            $this->locale_code[osc_current_user_locale()] = osc_current_user_locale();
-                        }
-                    }
-                    $this->dao->where(sprintf("( d.fk_c_locale_code LIKE '%s' )", implode("' d.fk_c_locale_code LIKE '", $this->locale_code)));
                 }
 
                 // item conditions


### PR DESCRIPTION
I removed these lines to be able to search a pattern simultaneously with all languages. (the last line was also very strange and can't work with more than one language)

It's strange to search a pattern only for the current language of the user. 

When I set my language to english and I'm on a French website, I want to be able to search a pattern on french listings and not only on english listings.   

It's also very useful for the admin. 

``` PHP
 if(empty($this->locale_code)) {
         if(OC_ADMIN) {
            $this->locale_code[osc_current_admin_locale()] = osc_current_admin_locale();
          } else {
           $this->locale_code[osc_current_user_locale()] = osc_current_user_locale();
           }
       }
$this->dao->where(sprintf("( d.fk_c_locale_code LIKE '%s' )", implode("' d.fk_c_locale_code LIKE '", $this->locale_code)));
```
