### PR TITLE
insert QUERY TIME descriptive name before query duration time

### DIFF
--- a/oc-includes/osclass/Logger/LogDatabase.php
+++ b/oc-includes/osclass/Logger/LogDatabase.php
@@ -143,7 +143,7 @@
             fwrite($fp, '==================================================' . PHP_EOL . PHP_EOL);
 
             foreach($this->messages as $msg) {
-                fwrite($fp, $msg['query_time'] . PHP_EOL);
+                fwrite($fp, 'QUERY TIME' . ' ' . $msg['query_time'] . PHP_EOL);
                 if( $msg['errno'] != 0 ) {
                     fwrite($fp, 'Error number: ' . $msg['errno'] . PHP_EOL);
                     fwrite($fp, 'Error description: ' . $msg['error'] . PHP_EOL);


### PR DESCRIPTION
by adding a unique row identifier / descriptive name before timestamp we can quickly examine all rows w/ slow queries at once, instead of using regex to locate them