### PR TITLE
Remove CSRF check on item add post and edit post

### DIFF
--- a/oc-includes/osclass/controller/item.php
+++ b/oc-includes/osclass/controller/item.php
@@ -95,7 +95,6 @@
                     $this->doView('item-post.php');
                 break;
                 case 'item_add_post': //post_item
-                    osc_csrf_check();
                     if( osc_reg_user_post() && $this->user == null ) {
                         osc_add_flash_warning_message( _m('Only registered users are allowed to post listings') );
                         $this->redirectTo( osc_base_url(true) );
@@ -200,8 +199,6 @@
                                     }
                 break;
                 case 'item_edit_post':
-                    osc_csrf_check();
-
                     $secret = Params::getParam('secret');
                     $id     = Params::getParam('id');
                     $item   = $this->itemManager->listWhere("i.pk_i_id = %d AND ((i.s_secret = %s AND i.fk_i_user_id IS NULL) OR (i.fk_i_user_id = %d))", (int)($id), $secret, (int)($this->userId));


### PR DESCRIPTION
Hi,

Maybe it's not the best solution, but doing a CSRF check on item post and edit isn't really user friendly.

We have so many users who are losing their descriptions because they are posting an item and with some other tab they are surfing on our website. If they cross an other form with csrf check, they lose their token from the session. 

So when they come back on their description, they click on post or edit my item, they lose all their modifications. 
And sometimes they have write their description during more than 15 minutes.

Any best idea ?

Regards,
