### PR TITLE
Make View::_current() support for looping on array of anything

### DIFF
--- a/oc-includes/osclass/core/View.php
+++ b/oc-includes/osclass/core/View.php
@@ -75,10 +75,10 @@
 
         function _current($key)
         {
-            if ( isset($this->aCurrent[$key]) && is_array($this->aCurrent[$key]) ) {
-                return $this->aCurrent[$key];
-            } elseif ( is_array($this->aExported[$key]) ) {
-                $this->aCurrent[$key] = current( $this->aExported[$key] );
+            if(is_array($this->aExported[$key])) {
+                if(!isset($this->aCurrent[$key]) ) {
+                   $this->aCurrent[$key] = current( $this->aExported[$key] );
+                }
                 return $this->aCurrent[$key];
             }
             return '';


### PR DESCRIPTION
Current View::_current() method only supports looping over arrays of arrays.

We often export lists (arrays) of objects like in our messenger plugin.

For example, our exported `mdh_messages` variables looks like that :

```
Array(
    [0] => Madhouse_Messenger_Message (object)
    [1] => Madhouse_Messenger_Message (object)
    [2] => Madhouse_Messenger_Message (object)
)
```

We had to make a fix because of the `is_array($this->aCurrent[$key])` condition in the current code :

``` PHP
function _current($key)
{
    if ( isset($this->aCurrent[$key]) && is_array($this->aCurrent[$key]) ) {
        return $this->aCurrent[$key];
    } elseif ( is_array($this->aExported[$key]) ) {
        $this->aCurrent[$key] = current( $this->aExported[$key] );
        return $this->aCurrent[$key];
    }
    return '';
}
```

This fix enables looping around arrays of anything (ints, strings, objects, etc) and simplifies a bit the algorithm.

``` PHP
function _current($key)
{
    if(is_array($this->aExported[$key])) {
        if(!isset($this->aCurrent[$key]) ) {
           $this->aCurrent[$key] = current( $this->aExported[$key] );
        }
        return $this->aCurrent[$key];
    }
    return '';
}
```
