### PR TITLE
Catch exceptions when loading plugin files

### DIFF
--- a/oc-includes/osclass/classes/Plugins.php
+++ b/oc-includes/osclass/classes/Plugins.php
@@ -220,9 +220,9 @@
                 return array('error_code' => 'error_file');
             }
 
-            include_once( osc_plugins_path() . $path );
-
             try {
+                include_once( osc_plugins_path() . $path );
+                
                 self::runHook('install_' . $path);
             } catch(Exception $e) {
                 return array('error_code' => 'custom_error' ,'msg' => $e->getMessage());


### PR DESCRIPTION
There is no catching for exceptions on loading the plugin files.

Error handling is manage by 
```PHP
return array('error_code' => 'error_output', 'output' => ob_get_clean());
```

Regular errors will still be handled that way.

Exceptions will be displayed nicely.