### PR TITLE
Fix to be able to load a plugin view inside a theme

### DIFF
--- a/oc-includes/osclass/controller/custom.php
+++ b/oc-includes/osclass/controller/custom.php
@@ -49,7 +49,7 @@
             }
 
             // check if the file exists
-            if( !file_exists(osc_plugins_path() . $file) && !file_exists(WebThemes::newInstance()->getCurrentThemePath() . $file) ) {
+            if( !file_exists(osc_plugins_path() . $file) && !file_exists(WebThemes::newInstance()->getCurrentThemePath() . "plugins/" . $file) ) {
                 $this->do404();
                 return;
             }

--- a/oc-includes/osclass/controller/custom.php
+++ b/oc-includes/osclass/controller/custom.php
@@ -49,7 +49,7 @@
             }
 
             // check if the file exists
-            if( !file_exists(osc_plugins_path() . $file) && !file_exists(osc_themes_path() . $file) ) {
+            if( !file_exists(osc_plugins_path() . $file) && !file_exists(WebThemes::newInstance()->getCurrentThemePath() . $file) ) {
                 $this->do404();
                 return;
             }

--- a/oc-includes/osclass/helpers/hTheme.php
+++ b/oc-includes/osclass/helpers/hTheme.php
@@ -39,8 +39,8 @@
         // Clean $file to prevent hacking of some type
         osc_sanitize_url($file);
         $file = str_replace("../", "", str_replace("..\\", "", str_replace("://", "", preg_replace("|http([s]*)|", "", $file))));
-        if(file_exists(WebThemes::newInstance()->getCurrentThemePath() . $file)) {
-            include WebThemes::newInstance()->getCurrentThemePath() . $file;
+        if(file_exists(WebThemes::newInstance()->getCurrentThemePath() . "plugins/" . $file)) {
+            include WebThemes::newInstance()->getCurrentThemePath() . "plugins/" . $file;
         } else if(file_exists(osc_plugins_path() . $file)) {
             include osc_plugins_path() . $file;
         }

--- a/oc-includes/osclass/helpers/hTheme.php
+++ b/oc-includes/osclass/helpers/hTheme.php
@@ -39,8 +39,8 @@
         // Clean $file to prevent hacking of some type
         osc_sanitize_url($file);
         $file = str_replace("../", "", str_replace("..\\", "", str_replace("://", "", preg_replace("|http([s]*)|", "", $file))));
-        if(file_exists(osc_theme() . $file)) {
-            include osc_themes_path() . $file;
+        if(file_exists(WebThemes::newInstance()->getCurrentThemePath() . $file)) {
+            include WebThemes::newInstance()->getCurrentThemePath() . $file;
         } else if(file_exists(osc_plugins_path() . $file)) {
             include osc_plugins_path() . $file;
         }


### PR DESCRIPTION
Fix the wrong test to know if a plugin view exist in a theme.

The old test wouldn't have never found the file in the theme.

Now if a view in a plugin is stored in a theme with the same tree structure hTheme.php will load the one in the theme.

Tree exemple :
oc-content/plugins/{plugin_name}/views/my-view.php
oc-content/themes/{my_current_theme}/{plugin_name}/views/my-view.php

This allow people to override plugin's views without editing a plugin but a theme.
