### PR TITLE
Fix bug on extendData

### DIFF
--- a/oc-includes/osclass/model/Item.php
+++ b/oc-includes/osclass/model/Item.php
@@ -1231,6 +1231,7 @@
 //                $this->dao->where(DB_TABLE_PREFIX.'t_item_stats.fk_i_item_id', $item['pk_i_id']);
                 $this->dao->where('s.fk_i_item_id', $item['pk_i_id']);
                 $this->dao->where('cd.fk_i_category_id', $item['fk_i_category_id']);
+                $this->dao->where('cd.fk_c_locale_code', $prefLocale);
                 // group by item_id
                 $this->dao->groupBy('fk_i_item_id');
 


### PR DESCRIPTION
Fix bug if you have more than one category description.

The SUM is multiplied by the number of category description because here we use a simple FROM and not a JOIN.

By exemple if I have 3 languages and 3 category descriptions (One for each language) my result for the number or view and spam of an item will be multiplied by 3.
