### PR TITLE
Huge image process optimization (avoid allocated memory problem)

### DIFF
--- a/oc-includes/osclass/ItemActions.php
+++ b/oc-includes/osclass/ItemActions.php
@@ -1391,7 +1391,7 @@
                             // Create normal size
                             $normal_path = $path = $tmpName."_normal";
                             $size = explode('x', osc_normal_dimensions());
-                            $img = ImageResizer::fromFile($tmpName)->autoRotate();
+                            $img = $imgres->autoRotate();
                             
                             $img = $img->resizeTo($size[0], $size[1]);
                             if( osc_is_watermark_text() ) {


### PR DESCRIPTION
This modification avoid a lot of allocated memory problem.

I don't create two object with my original image store in memory but only one object with my original picture in memory.

This allow on our website to upload an image of 5600x3000px.

Before I wasn't able to upload an image of 3800x2000px
