### PR TITLE
Log: allow cron to insert logs in oc_t_log table

### DIFF
--- a/oc-includes/osclass/model/Log.php
+++ b/oc-includes/osclass/model/Log.php
@@ -70,8 +70,8 @@
          */
         public function insertLog($section, $action, $id, $data, $who, $whoId)
         {
-            if (!isset($_SERVER) || (isset($_SERVER['REMOTE_ADDR'] && $_SERVER['REMOTE_ADDR'] == "")) {
-                // Makes log possible for cron scripts.
+            if (!isset($_SERVER) || (isset($_SERVER) && !isset($_SERVER['REMOTE_ADDR']))) {
+                // CRON.
                 $_SERVER['REMOTE_ADDR']= '127.0.0.1';
             }
 

--- a/oc-includes/osclass/model/Log.php
+++ b/oc-includes/osclass/model/Log.php
@@ -70,6 +70,11 @@
          */
         public function insertLog($section, $action, $id, $data, $who, $whoId)
         {
+            if (!isset($_SERVER) || (isset($_SERVER['REMOTE_ADDR'] && $_SERVER['REMOTE_ADDR'] == "")) {
+                // Makes log possible for cron scripts.
+                $_SERVER['REMOTE_ADDR']= '127.0.0.1';
+            }
+
             $array_set = array(
                 'dt_date'       => date('Y-m-d H:i:s'),
                 's_section'     => $section,


### PR DESCRIPTION
In `oc_t_log`, the `s_ip` column is `NOT NULL`

When PHP is running from the command-line, `$_SERVER` is null, then it's impossible to insert logs from cron jobs.

``` php
if (!isset($_SERVER) || (isset($_SERVER) && !isset($_SERVER['REMOTE_ADDR']))) {
    // CRON.
    $_SERVER['REMOTE_ADDR']= '127.0.0.1';
}
```

It may be wise to switch the `s_ip` to `NULL` and make the update in the next release, don't know what's the method you prefer.
