### PR TITLE
Allow scroll y for all submenu and not only menu_plugins

### DIFF
--- a/oc-admin/themes/modern/less/sidebar.less
+++ b/oc-admin/themes/modern/less/sidebar.less
@@ -33,7 +33,7 @@
 }
 #sidebar .oscmenu > li > ul{
     overflow: auto;
-    overflow-y:          hidden;
+    overflow-y:          scroll;
     overflow-x:          visible;
     max-height: 600%;
 }
@@ -47,9 +47,6 @@ body.compact #sidebar .oscmenu .current{
     background:          @color-gray-hardblack;
     -webkit-box-shadow: none;
     box-shadow: none;
-}
-body.compact #sidebar .oscmenu li#menu_plugins ul{
-    overflow-y:auto;
 }
 #show-more li{
     float:left;


### PR DESCRIPTION
This little change allow the scroll for other submenu.

Useful if a plugin add a new section with too many link in the submenu.
