### PR TITLE
Support for MariaDB (mysql community) for Categories

### DIFF
--- a/oc-includes/osclass/model/Category.php
+++ b/oc-includes/osclass/model/Category.php
@@ -89,18 +89,17 @@
                 $this->dao->where( $where );
             }
 
-            $this->dao->select( sprintf("a.*, b.*, c.i_num_items, FIELD(fk_c_locale_code, '%s') as locale_order", $this->dao->connId->real_escape_string($this->_language) ) );
+            $this->dao->select("a.*, b.*, c.i_num_items");
             $this->dao->from( $this->getTableName().' as a' );
-            $this->dao->join(DB_TABLE_PREFIX.'t_category_description as b', 'a.pk_i_id = b.fk_i_category_id', 'INNER');
+            $this->dao->join(
+                DB_TABLE_PREFIX.'t_category_description as b',
+                sprintf(
+                    '(a.pk_i_id = b.fk_i_category_id AND b.fk_c_locale_code = "%s")',
+                    $this->dao->connId->real_escape_string($this->_language)
+                ),
+                'INNER'
+            );
             $this->dao->join(DB_TABLE_PREFIX.'t_category_stats  as c ', 'a.pk_i_id = c.fk_i_category_id', 'LEFT');
-            $this->dao->where("b.s_name != ''");
-            $this->dao->orderBy('locale_order', 'DESC');
-            $subquery = $this->dao->_getSelect();
-            $this->dao->_resetSelect();
-
-            $this->dao->select();
-            $this->dao->from( sprintf( '(%s) dummytable', $subquery ) ); // $subselect.'  dummytable');
-            $this->dao->groupBy('pk_i_id');
             $this->dao->orderBy('i_position', 'ASC');
             $rs = $this->dao->get();
 
@@ -124,31 +123,10 @@
          */
         public function listEnabled()
         {
-            $this->dao->select( sprintf("a.*, b.*, c.i_num_items, FIELD(fk_c_locale_code, '%s') as locale_order", $this->dao->connId->real_escape_string($this->_language) ) );
-            $this->dao->from( $this->getTableName().' as a' );
-            $this->dao->join(DB_TABLE_PREFIX.'t_category_description as b', 'a.pk_i_id = b.fk_i_category_id', 'INNER');
-            $this->dao->join(DB_TABLE_PREFIX.'t_category_stats  as c ', 'a.pk_i_id = c.fk_i_category_id', 'LEFT');
             $this->dao->where("b.s_name != ''");
             $this->dao->where("a.b_enabled = 1");
-            $this->dao->orderBy('locale_order', 'DESC');
-            $subquery = $this->dao->_getSelect();
-            $this->dao->_resetSelect();
 
-            $this->dao->select();
-            $this->dao->from( sprintf( '(%s) dummytable', $subquery ) ); // $subselect.'  dummytable');
-            $this->dao->groupBy('pk_i_id');
-            $this->dao->orderBy('i_position', 'ASC');
-            $rs = $this->dao->get();
-
-            if( $rs === false ) {
-                return array();
-            }
-
-            if( $rs->numRows() == 0 ) {
-                return array();
-            }
-
-            return $rs->result();
+            return $this->listWhere();
         }
 
         /**


### PR DESCRIPTION
[MariaDB](url) is the community-developed fork of MySQL created by Michael "Monty" Widenius (same creator as MySQL) after MySQL has been acquired by Sun (Oracle).
## MariaDB vs MySQL

It turns out that it differs from MySQL implementation on some feature. One of those is subquery / `GROUP BY` by and `ORDER BY` handling. It's not a bug but a choice of implementation for which reasons and documentation can be found here:
[Why is ORDER BY in a FROM Subquery Ignored?](https://mariadb.com/kb/en/mariadb/why-is-order-by-in-a-from-subquery-ignored/)
## What happened with Categories ?

The locale that was selected was not the right one since the ORDER BY was ignored, it took the first one, in an arbitrary order. The problem is better explained in [this StackOverflow issue](http://stackoverflow.com/questions/26372511/mysql-order-by-inside-subquery).
## The fix.

We updated – with @groomain – the query in `::listWhere()` to join on current locale and remove the necessity of doing a subquery.

I didn't find any similar queries in any other DAO. If you think of something, don't hesitate to give me the info and I'll add it to this PR.

Thanks a lot !
