### PR TITLE
Bug if the image isn't uploaded (try to rotate it)

### DIFF
--- a/oc-includes/osclass/controller/ajax.php
+++ b/oc-includes/osclass/controller/ajax.php
@@ -293,9 +293,12 @@
                     $filename = uniqid("qqfile_").".".$original['extension'];
                     $result = $uploader->handleUpload(osc_content_path().'uploads/temp/'.$filename);
 
-                    // auto rotate
-                    $img = ImageResizer::fromFile(osc_content_path().'uploads/temp/'.$filename)->autoRotate();
-                    $img->saveToFile(osc_content_path().'uploads/temp/auto_'.$filename, $original['extension']);
+                    if (!isset($result['error'])) {
+                        $img = ImageResizer::fromFile(osc_content_path().'uploads/temp/'.$filename)->autoRotate();
+                        $img->saveToFile(osc_content_path().'uploads/temp/auto_'.$filename, $original['extension']);
+
+                        $result['uploadName'] = 'auto_'.$filename;
+                    }
 
                     $result['uploadName'] = 'auto_'.$filename;
                     echo htmlspecialchars(json_encode($result), ENT_NOQUOTES);


### PR DESCRIPTION
When the file failed to be uploaded osclass try to rotate it.

By the way I think in this file osclass should return JSON type. But It can create some bug in the front with the uploader so I haven't added it to this pull request.

``` PHP
header('Content-Type: application/json');
```

And return an 400 error if the file isn't uploaded.

``` PHP
header('HTTP/1.1 400 Bad Request');
```
