### PR TITLE
Fix url bug with child-themes

### DIFF
--- a/oc-includes/osclass/helpers/hDefines.php
+++ b/oc-includes/osclass/helpers/hDefines.php
@@ -221,7 +221,6 @@
         $info = WebThemes::newInstance()->loadThemeInfo(WebThemes::newInstance()->getCurrentTheme());
         if (!file_exists(WebThemes::newInstance()->getCurrentThemePath() . $file) && $info['template'] != ''){
             WebThemes::newInstance()->setParentTheme();
-            return WebThemes::newInstance()->getCurrentThemeUrl() . $file;
         }
         return WebThemes::newInstance()->getCurrentThemeUrl() . $file;
     }

--- a/oc-includes/osclass/helpers/hDefines.php
+++ b/oc-includes/osclass/helpers/hDefines.php
@@ -218,6 +218,11 @@
      * @return string
      */
     function osc_current_web_theme_url($file = '') {
+        $info = WebThemes::newInstance()->loadThemeInfo(WebThemes::newInstance()->getCurrentTheme());
+        if (!file_exists(WebThemes::newInstance()->getCurrentThemePath() . $file) && $info['template'] != ''){
+            WebThemes::newInstance()->setParentTheme();
+            return WebThemes::newInstance()->getCurrentThemeUrl() . $file;
+        }
         return WebThemes::newInstance()->getCurrentThemeUrl() . $file;
     }
 


### PR DESCRIPTION
Child themes can't work properly if the files missing in the child theme aren't loaded with the parent. 

Fix osc_current_web_theme_url()
