### PR TITLE
Add $flash_error to pre_item_add and pre_item_edit hooks

### DIFF
--- a/oc-includes/osclass/ItemActions.php
+++ b/oc-includes/osclass/ItemActions.php
@@ -167,7 +167,7 @@
             // hook pre add or edit
             // DEPRECATED: pre_item_post will be removed in 3.4
             osc_run_hook('pre_item_post');
-            osc_run_hook('pre_item_add', $aItem);
+            osc_run_hook('pre_item_add', $aItem, $flash_error);
 
             // Handle error
             if ($flash_error) {
@@ -371,7 +371,7 @@
             // hook pre add or edit
             // DEPRECATED : preitem_psot will be removed in 3.4
             osc_run_hook('pre_item_post');
-            osc_run_hook('pre_item_edit', $aItem);
+            osc_run_hook('pre_item_edit', $aItem, $flash_error);
 
             // Handle error
             if ($flash_error) {


### PR DESCRIPTION
I've added $flash_error in pre_item_add and pre_item_edit hooks to know if there is error while we're in the hook.
