### PR TITLE
Small fix to be able to add category or a location

### DIFF
--- a/oc-includes/osclass/model/Search.php
+++ b/oc-includes/osclass/model/Search.php
@@ -788,6 +788,8 @@
          */
         private function _makeSQLPremium($num = 2)
         {
+            $arrayConditions    = $this->_conditions();
+            
             if ($this->withPattern ) {
                 // sub select for JOIN ----------------------
                 $this->dao->select('distinct d.fk_i_item_id');


### PR DESCRIPTION
If _conditions isn't called in makeSQLPremium users aren't able to filter premium sql request on Location or Category. 

It's because _conditions set withCategoryId and withLocations variable.
