### PR TITLE
Ambiguous column name in Region fro ajax request

### DIFF
--- a/oc-includes/osclass/model/Region.php
+++ b/oc-includes/osclass/model/Region.php
@@ -128,7 +128,7 @@
             $country = trim($country);
             $this->dao->select('a.pk_i_id as id, a.s_name as label, a.s_name as value');
             $this->dao->from($this->getTableName() . ' as a');
-            $this->dao->like('s_name', $query, 'after');
+            $this->dao->like('a.s_name', $query, 'after');
             if($country != null ) {
                 if(strlen($country)==2) {
                     $this->dao->where('a.fk_c_country_code', strtolower($country));


### PR DESCRIPTION
Fix to remove an ambiguous column name in ajax request for regions
