### PR TITLE
Fix Warning: exif_read_data(...): Illegal IFD size

### DIFF
--- a/oc-includes/osclass/classes/ImageResizer.php
+++ b/oc-includes/osclass/classes/ImageResizer.php
@@ -56,7 +56,7 @@
 
                 $this->_exif = array();
                 if(@$this->image_info['mime']=='image/jpeg' && function_exists('exif_read_data')) {
-                    $this->_exif = exif_read_data($imagePath);
+                    $this->_exif = @exif_read_data($imagePath);
                 }
 
             }


### PR DESCRIPTION
Sometimes we have this error on some production environment and not with all images...

exif_read_data(...): Illegal IFD size

Fix with a simple @.

http://stackoverflow.com/questions/5184748/php-bad-exif-data-warnings-what-to-do

Maybe
