### PR TITLE
[hotfixes] Solve fatal error with Params::getFiles() method

### DIFF
--- a/oc-includes/osclass/core/Params.php
+++ b/oc-includes/osclass/core/Params.php
@@ -107,7 +107,7 @@
                 return ($_FILES[$param]);
             }
 
-            return "";
+            return array();
         }
 
         static function getParamsAsArray($what = "", $htmlencode = false, $xss_check = true, $quotes_encode = true)


### PR DESCRIPTION
When adding or editing items, ``Params::getFiles()`` method return a empty string when no files are added, causing a ``Fatal error: Cannot use string offset as an array in ...`` when files are uploaded with ajax.

This PR update the above method to return a empty array and solve the issue.