### PR TITLE
cron fix & refact

### DIFF
--- a/oc-includes/osclass/cron.php
+++ b/oc-includes/osclass/cron.php
@@ -55,19 +55,14 @@
                 }
             }
 
-            $qqfiles = glob(osc_content_path().'uploads/temp/qqfile_*');
-            if(is_array($qqfiles)) {
-                foreach($qqfiles as $qqfile) {
-                    if((time()-filectime($qqfile))>(2*3600)) {
-                        @unlink($qqfile);
-                    }
-                }
-            }
-            $auto_qqfiles = glob(osc_content_path().'uploads/temp/auto_qqfile_*');
-            if(is_array($auto_qqfiles)) {
-                foreach($auto_qqfiles as $auto_qqfile) {
-                    if((time()-filectime($auto_qqfile))>(2*3600)) {
-                        @unlink($auto_qqfile);
+            $qqprefixes = array('qqfile_*', 'auto_qqfile_*');
+            foreach ($qqprefixes as $qqprefix) {
+                $qqfiles = glob(osc_content_path().'uploads/temp/'.$qqprefix);
+                if(is_array($qqfiles)) {
+                    foreach($qqfiles as $qqfile) {
+                        if((time()-filemtime($qqfile))>(2*3600)) {
+                            @unlink($qqfile);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Hi, after some checks on some of my dev and production servers, I've noticed that certain very very old temp qqfiles are never removed. Their modified date is several months old, so by all reasoning, they should all met 2*3600 condition and be removed long time ago. Yet, it never happens.

Simple test `time()-filectime()` revealed puzzling thing at first - that `filectime()` [and consequently, time difference] resets every full hour, so that condition in cron cannot ever be reached, leaving this orphaned files forever to reside on the server.

Then I recalled that I run a custom shell script on all my servers that every full hour changes/resets owners/perms of public dirs and files to make sure they are ok, in case I change things as root or temporarily play with rwx bits. Every time this happens, filectime() will properly return the date when file/dir inode data was modified, instead of file *itself*.

few examples: (test ran @ ~23:55, some 3300 seconds from full hour)
>/.../oc-content/uploads/temp/qqfile_584f400aee296.jpg | filectime: 2017-03-04 23:00:47 | filemtime: 2016-12-13 01:25:46 | [time()-filectime($qqfile)] diff: 3243

>/.../oc-content/uploads/temp/qqfile_584f400b2c126.jpg | filectime: 2017-03-04 23:00:47 | filemtime: 2016-12-13 01:25:47 | [time()-filectime($qqfile)] diff: 3243

>/.../oc-content/uploads/temp/qqfile_584f400d0ed68.png | filectime: 2017-03-04 23:00:47 | filemtime: 2016-12-13 01:25:48 | [time()-filectime($qqfile)] diff: 3243

--------------------------------------------------------------------------------------

tl:dr; bottom line, we should use `filemtime()` as it will return the value we expect, regardless of inode change.
Thanks!