### PR TITLE
session_start() fix

### DIFF
--- a/oc-includes/osclass/core/Session.php
+++ b/oc-includes/osclass/core/Session.php
@@ -43,11 +43,13 @@
                 true
             );
 
-            session_name('osclass');
-            session_start();
+            if( !isset($_SESSION) ) {
+                session_name('osclass');
+                session_start();
+            }
 
             $this->session = $_SESSION;
-            if ($this->_get('messages') == '') {
+            if( $this->_get('messages') == '' ) {
                 $this->_set( 'messages', array() );
             }
             if( $this->_get('keepForm') == '' ){


### PR DESCRIPTION
/ Do not try to start new session, if already started. /

Hi, I am using an auto-prepend script before Osclass runs, and I need to store some things into session for proper operation. Without this modification trying to start new session when it is already started will generate a lot of notices in the logs with each new request. I know that I can disable auto session start in .ini, but it is easier this way.

Thanks