### PR TITLE
Add 'mbstring' extension as installation requirement

### DIFF
--- a/oc-includes/osclass/install-functions.php
+++ b/oc-includes/osclass/install-functions.php
@@ -111,10 +111,10 @@ function get_requirements( ) {
             'fn' => extension_loaded('gd'),
             'solution' => __('GD extension is required. How to <a target="_blank" href="http://www.php.net/manual/en/image.setup.php">install/configure</a>.')),
 
-        #'MB extension for PHP' => array(
-        #    'requirement' => __('Mbstring extension for PHP'),
-        #    'fn' => extension_loaded('mbstring'),
-        #    'solution' => __('Mbstring extension is required. How to <a target="_blank" href="http://php.net/manual/en/mbstring.setup.php">install/configure</a>.')),
+        'MB extension for PHP' => array(
+            'requirement' => __('Mbstring extension for PHP'),
+            'fn' => extension_loaded('mbstring'),
+            'solution' => __('Mbstring extension is required. How to <a target="_blank" href="http://php.net/manual/en/mbstring.setup.php">install/configure</a>.')),
 
         'Folder <code>oc-content/uploads</code> exists' => array(
             'requirement' => __('Folder <code>oc-content/uploads</code> exists'),

--- a/oc-includes/osclass/install-functions.php
+++ b/oc-includes/osclass/install-functions.php
@@ -110,6 +110,11 @@ function get_requirements( ) {
             'fn' => extension_loaded('gd'),
             'solution' => __('GD extension is required. How to <a target="_blank" href="http://www.php.net/manual/en/image.setup.php">install/configure</a>.')),
 
+        'MB extension for PHP' => array(
+            'requirement' => __('Mbstring extension for PHP'),
+            'fn' => extension_loaded('mbstring'),
+            'solution' => __('Mbstring extension is required. How to <a target="_blank" href="http://php.net/manual/en/mbstring.setup.php">install/configure</a>.')),
+
         'Folder <code>oc-content/uploads</code> exists' => array(
             'requirement' => __('Folder <code>oc-content/uploads</code> exists'),
             'fn' => file_exists( ABS_PATH . 'oc-content/uploads/' ),

--- a/oc-includes/osclass/install-functions.php
+++ b/oc-includes/osclass/install-functions.php
@@ -17,6 +17,7 @@
 
 
 require_once dirname(dirname(__FILE__)) . '/htmlpurifier/HTMLPurifier.auto.php';
+require_once dirname(dirname(__FILE__)) . '/osclass/compatibility.php';
 function _purify($value, $xss_check)
 {
     if( !$xss_check ) {
@@ -110,10 +111,10 @@ function get_requirements( ) {
             'fn' => extension_loaded('gd'),
             'solution' => __('GD extension is required. How to <a target="_blank" href="http://www.php.net/manual/en/image.setup.php">install/configure</a>.')),
 
-        'MB extension for PHP' => array(
-            'requirement' => __('Mbstring extension for PHP'),
-            'fn' => extension_loaded('mbstring'),
-            'solution' => __('Mbstring extension is required. How to <a target="_blank" href="http://php.net/manual/en/mbstring.setup.php">install/configure</a>.')),
+        #'MB extension for PHP' => array(
+        #    'requirement' => __('Mbstring extension for PHP'),
+        #    'fn' => extension_loaded('mbstring'),
+        #    'solution' => __('Mbstring extension is required. How to <a target="_blank" href="http://php.net/manual/en/mbstring.setup.php">install/configure</a>.')),
 
         'Folder <code>oc-content/uploads</code> exists' => array(
             'requirement' => __('Folder <code>oc-content/uploads</code> exists'),
@@ -646,7 +647,6 @@ function finish_installation( $password ) {
     require_once LIB_PATH . 'osclass/model/Category.php';
     require_once LIB_PATH . 'osclass/model/Item.php';
     require_once LIB_PATH . 'osclass/helpers/hPlugins.php';
-    require_once LIB_PATH . 'osclass/compatibility.php';
     require_once LIB_PATH . 'osclass/classes/Plugins.php';
 
     $data = array();


### PR DESCRIPTION
### Problem
Trying to install/run the osclass without the _mbstring extension_, always result in the following error:
```php
PHP Fatal error:  Call to undefined function mb_strlen() in /var/www/html/oc-includes/osclass/helpers/hValidate.php on line 123, referer: http://blablabla.test/oc-includes/osclass/install.php?step=2
```

The problem is that the **mbstring extension** is not enabled and the file _compatibility.php_ that declares the function _mb_strlen()_ , in case the extension isn't enabled, is included only when the installation is finished, how you can check bellow:

```php
# -- File install-functions.php
function finish_installation( $password ) {
    
    // function code ...
    require_once LIB_PATH . 'osclass/compatibility.php';
    // function code ...
}
```

But the validation that uses the function is called during the _example data insertion_, how you can check below:

```php
# -- File install-functions.php
function oc_install_example_data() {

    // function code ...
    require_once LIB_PATH . 'osclass/helpers/hValidate.php';
    // function code ...
}
```

### Solution
- Add the mbstring extension as a requirement of the platform.
- Move the compatibility functions to be included not only in function scope. (this is not that necessary, considering that we are requiring the mbstring extension)

Tested with:
- PHP 5.6
- PHP 7