### PR TITLE
Fixes recaptcha checking in password recovery. 

### DIFF
--- a/oc-includes/osclass/UserActions.php
+++ b/oc-includes/osclass/UserActions.php
@@ -229,7 +229,7 @@
             $user = User::newInstance()->findByEmail( Params::getParam('s_email') );
             Session::newInstance()->_set( 'recover_time', time() );
 
-            if ( (osc_recaptcha_private_key() != '') ) {
+            if ( (osc_recaptcha_private_key() != '') && Session::newInstance()->_get('recover_captcha_not_set')!=1) {
                 if( !osc_check_recaptcha() ) {
                     return 2; // BREAK THE PROCESS, THE RECAPTCHA IS WRONG
                 }

--- a/oc-includes/osclass/helpers/hUtils.php
+++ b/oc-includes/osclass/helpers/hUtils.php
@@ -109,9 +109,13 @@ function osc_show_recaptcha($section = '') {
     if(osc_recaptcha_version()=="2") {
         switch($section) {
             case('recover_password'):
+                Session::newInstance()->_set('recover_captcha_not_set',0);
                 $time  = Session::newInstance()->_get('recover_time');
                 if((time()-$time)<=1200) {
                     echo _osc_recaptcha_get_html(osc_recaptcha_public_key(), substr(osc_language(), 0, 2))."<br />";
+                }
+                else{
+                    Session::newInstance()->_set('recover_captcha_not_set',1);
                 }
                 break;
 


### PR DESCRIPTION
The password recovery page only shows a recaptcha if a previous recovery has been made within the past two minutes. But the backend logic checks the recaptcha even when one hasn't been shown meaning that password reset requests fail. This pull request sets a server side session variable which bypasses the recaptcha check if one wasn't shown in the form.