### PR TITLE
Fix Return the correct message.

### DIFF
--- a/oc-admin/ajax/ajax.php
+++ b/oc-admin/ajax/ajax.php
@@ -345,7 +345,7 @@
                     if($error) {
                         $result = array( 'error' => $message);
                     } else {
-                        $result = array( 'ok' => __("Saved") );
+                        $result = array( 'ok' => $message );
                     }
                     echo json_encode($result);
 


### PR DESCRIPTION
The action is **delete_category** and the appropriate message is assigned on the same block, but eventually not returned as intended.