### PR TITLE
Quarantine __autoload defs for PHP 7.2 compat

### DIFF
--- a/oc-includes/htmlpurifier/HTMLPurifier.autoload-legacy.php
+++ b/oc-includes/htmlpurifier/HTMLPurifier.autoload-legacy.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Legacy autoloader for systems lacking spl_autoload_register
+ *
+ * Must be separate to prevent deprecation warning on PHP 7.2
+ */
+
+function __autoload($class)
+{
+    return HTMLPurifier_Bootstrap::autoload($class);
+}
+
+// vim: et sw=4 sts=4

--- a/oc-includes/htmlpurifier/HTMLPurifier.autoload.php
+++ b/oc-includes/htmlpurifier/HTMLPurifier.autoload.php
@@ -14,9 +14,7 @@ if (function_exists('spl_autoload_register') && function_exists('spl_autoload_un
         spl_autoload_register('__autoload');
     }
 } elseif (!function_exists('__autoload')) {
-    function __autoload($class) {
-        return HTMLPurifier_Bootstrap::autoload($class);
-    }
+    require dirname(__FILE__) . '/HTMLPurifier.autoload-legacy.php';
 }
 
 if (ini_get('zend.ze1_compatibility_mode')) {


### PR DESCRIPTION
To prevent deprecation on PHP 7.2
reference: https://github.com/ezyang/htmlpurifier/commit/bb7ad665265a29303ec59918f0c1832528bdc509