### PR TITLE
extra column added for item type

### DIFF
--- a/oc-includes/osclass/installer/struct.sql
+++ b/oc-includes/osclass/installer/struct.sql
@@ -215,7 +215,7 @@ CREATE TABLE /*TABLE_PREFIX*/t_item (
     dt_mod_date DATETIME NULL,
     f_price FLOAT NULL,
     i_price BIGINT(20) NULL,
-    i_type VARCHAR(40) NULL,
+    s_type VARCHAR(40) NULL,
     fk_c_currency_code CHAR(3) NULL,
     s_contact_name VARCHAR(100) NULL,
     s_contact_email VARCHAR(140) NOT NULL,

--- a/oc-includes/osclass/installer/struct.sql
+++ b/oc-includes/osclass/installer/struct.sql
@@ -215,6 +215,7 @@ CREATE TABLE /*TABLE_PREFIX*/t_item (
     dt_mod_date DATETIME NULL,
     f_price FLOAT NULL,
     i_price BIGINT(20) NULL,
+    i_type VARCHAR(40) NULL,
     fk_c_currency_code CHAR(3) NULL,
     s_contact_name VARCHAR(100) NULL,
     s_contact_email VARCHAR(140) NOT NULL,


### PR DESCRIPTION
Need extra column 'item_type' for the t_item table
it will make extend the special and simple items without creating the table for it. we can use the item as a blog, or custom post page and much more.